### PR TITLE
Target connection strings on feed level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Location of the cache can now be specified in the config.yml. Rationale: Easier way of dealing with multiple configurations, as each also requires a distinct cache.
+- [Issue #6](https://github.com/Necoro/feed2imap-go/issues/6): Support old-style configurations with imap targets on each feed. Restriction: Servers must be equal over all connection strings!
 ### Fixed
 - [Issue #62](https://github.com/Necoro/feed2imap-go/issues/62): Allow empty root folder.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ warning is issued when an option should now be in another place or is no longer 
 
 ### Unsupported features of feed2imap
 
-* IMAP-Target per Feed ([issue #6][i6]); targets only specify the folder relative to the global target
 * Maildir ([issue #4][i4])
+* Different IMAP servers in the same configuration file. Please use multiple config files, if this is needed (see also [issue #6][i6]).
 
 ## Installation
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -20,6 +20,11 @@ target:
 # The example from above would read:
 # target: imap://test%40example.com:passw0rd@mail.example.com:143/INBOX/Feeds
 
+# NB: Instead of specifying the target on the global level, for compatibility with old configurations, it is also allowed
+# to specify the full URL string for each feed.
+# When doing so, _all_ target strings must point to the same server, else an error will be thrown.
+# See https://github.com/Necoro/feed2imap-go/issues/6 for more details.
+
 ## Global Options
 # Location of the cache. Can also be overwritten on the command line.
 cache: "feed.cache"

--- a/internal/imap/folder.go
+++ b/internal/imap/folder.go
@@ -7,6 +7,10 @@ type Folder struct {
 	delimiter string
 }
 
+func (f Folder) IsBlank() bool {
+	return f.str == ""
+}
+
 func (f Folder) String() string {
 	return f.str
 }

--- a/internal/imap/imap.go
+++ b/internal/imap/imap.go
@@ -2,7 +2,6 @@ package imap
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Necoro/feed2imap-go/pkg/config"
 	"github.com/Necoro/feed2imap-go/pkg/log"
@@ -31,15 +30,11 @@ func Connect(url config.Url) (*Client, error) {
 	}
 	client.delimiter = delim
 
-	toplevel := url.Root
-	if toplevel[0] == '/' {
-		toplevel = toplevel[1:]
-	}
-	client.toplevel = client.folderName(strings.Split(toplevel, "/"))
+	client.toplevel = client.folderName(url.RootPath())
 
 	log.Printf("Determined '%s' as toplevel, with '%s' as delimiter", client.toplevel, client.delimiter)
 
-	if toplevel != "" {
+	if !client.toplevel.IsBlank() {
 		if err = conn.ensureFolder(client.toplevel); err != nil {
 			return nil, err
 		}

--- a/pkg/config/url.go
+++ b/pkg/config/url.go
@@ -64,12 +64,18 @@ func (u *Url) UnmarshalYAML(value *yaml.Node) (err error) {
 }
 
 func (u *Url) String() string {
+	scheme := u.Scheme + "://"
+
 	var pwd string
 	if u.Password != "" {
 		pwd = ":******"
 	}
+	var delim string
+	if pwd != "" || u.User != "" {
+		delim = "@"
+	}
 
-	return fmt.Sprintf("%s://%s%s@%s%s", u.Scheme, u.User, pwd, u.HostPort(), u.Root)
+	return scheme + u.User + pwd + delim + u.HostPort() + u.Root
 }
 
 func (u *Url) HostPort() string {

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -171,6 +171,12 @@ func TestBuildFeeds(tst *testing.T) {
 			},
 			result: Feeds{},
 		},
+		{name: "Maildir URL Target", wantErr: true, target: "",
+			feeds: []configGroupFeed{
+				{Target: n("maildir:///home/foo/INBOX/Feed"), Feed: feed{Name: "muh"}},
+			},
+			result: Feeds{},
+		},
 		{name: "Empty Group", wantErr: false, target: "",
 			feeds: []configGroupFeed{
 				{Group: group{Group: "G1"}},


### PR DESCRIPTION
Allow full connection strings on feed level, to support old-style feed2imap configurations.

Closes #6. 